### PR TITLE
utils: use BigNumber for toNonExponential

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -21,64 +21,8 @@ export function addressSlice(address, sliceLength = 10) {
  * @param {*} num_str
  */
 export function toNonExponential(num_str) {
-    num_str = num_str.toString();
-    if (num_str.indexOf("+") != -1) {
-        num_str = num_str.replace("+", "");
-    }
-    if (num_str.indexOf("E") != -1 || num_str.indexOf("e") != -1) {
-        var resValue = "",
-            power = "",
-            result = null,
-            dotIndex = 0,
-            resArr = [],
-            sym = "";
-        var numStr = num_str.toString();
-        if (numStr[0] == "-") {
-            numStr = numStr.substr(1);
-            sym = "-";
-        }
-        if (numStr.indexOf("E") != -1 || numStr.indexOf("e") != -1) {
-            var regExp = new RegExp(
-                "^(((\\d+.?\\d+)|(\\d+))[Ee]{1}((-(\\d+))|(\\d+)))$",
-                "ig"
-            );
-            result = regExp.exec(numStr);
-            if (result != null) {
-                resValue = result[2];
-                power = result[5];
-                result = null;
-            }
-            if (!resValue && !power) {
-                return false;
-            }
-            dotIndex = resValue.indexOf(".") == -1 ? 0 : resValue.indexOf(".");
-            resValue = resValue.replace(".", "");
-            resArr = resValue.split("");
-            if (Number(power) >= 0) {
-                var subres = resValue.substr(dotIndex);
-                power = Number(power);
-                for (var i = 0; i <= power - subres.length; i++) {
-                    resArr.push("0");
-                }
-                if (power - subres.length < 0) {
-                    resArr.splice(dotIndex + power, 0, ".");
-                }
-            } else {
-                power = power.replace("-", "");
-                power = Number(power);
-                for (var i = 0; i < power - dotIndex; i++) {
-                    resArr.unshift("0");
-                }
-                var n = power - dotIndex >= 0 ? 1 : -(power - dotIndex);
-                resArr.splice(n, 0, ".");
-            }
-        }
-        resValue = resArr.join("");
-
-        return sym + resValue;
-    } else {
-        return num_str;
-    }
+    const num_bn = new BigNumber(num_str);
+    return num_bn.toFixed();
 }
 /**
  * Accuracy conversion No accuracy to accuracy


### PR DESCRIPTION
The rest of the file uses bignumber.js as a library. Here I've swapped out toNonExponential's custom string based implementation to use BigNumber toFixed.

The purpose of this is to make it so that we don't have to maintain custom string-based math logic.

fixes #23 and #63