### PR TITLE
Open Welcome page in a persistent popup

### DIFF
--- a/src/background/messageListener.js
+++ b/src/background/messageListener.js
@@ -22,6 +22,7 @@ import {
   WALLET_SEND_RECLAIM_TRANSTRACTION,
   WALLET_IMPORT_OBSERVE_ACCOUNT,
   WALLET_RESET_LAST_ACTIVE_TIME,
+  WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP,
   GET_SIGN_PARAMS,
   DAPP_GET_APPROVE_ACCOUNT,
   DAPP_GET_CONNECT_STATUS,
@@ -35,6 +36,7 @@ import {
 import extension from 'extensionizer'
 import apiService from "./service/APIService";
 import extDappService from "./service/ExtDappService";
+import { openPopupWindow } from '../utils/popup';
 
 function internalMessageListener(message, sender, sendResponse) {
   const { messageSource, action, payload } = message;
@@ -148,6 +150,14 @@ function internalMessageListener(message, sender, sendResponse) {
       break
     case WALLET_RESET_LAST_ACTIVE_TIME:
       sendResponse(apiService.setLastActiveTime())
+      break
+    case WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP:
+      openPopupWindow(extension.extension.getURL(payload.route), 'persistentPopup', undefined, {
+        left: payload.left,
+        top: payload.top,
+      }).then((result) => {
+        sendResponse(result);
+      });
       break
     case GET_APP_LOCK_STATUS:
       sendResponse(apiService.getLockStatus())

--- a/src/constant/types.js
+++ b/src/constant/types.js
@@ -110,6 +110,11 @@ export const WALLET_GET_CREATE_MNEMONIC = "WALLET_GET_CREATE_MNEMONIC"
  */
 export const WALLET_RESET_LAST_ACTIVE_TIME = "WALLET_RESET_LAST_ACTIVE_TIME"
 
+/**
+ * Open route in persistent popup
+ */
+export const WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP = "WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP"
+
 // ====================================================================================bottom back to popup
 
 /**

--- a/src/popup/pages/Welcome/index.js
+++ b/src/popup/pages/Welcome/index.js
@@ -12,7 +12,7 @@ import {
 } from "../../../i18n";
 import { setLanguage } from "../../../reducers/appReducer";
 import { setWelcomeNextRoute } from "../../../reducers/cache";
-import { openCurrentRouteInPersistentPopup } from '../../../utils/popup';
+import { openCurrentRouteInPersistentTab } from '../../../utils/popup';
 import Button from "../../component/Button";
 import Select from "../../component/Select";
 import "./index.scss";
@@ -27,7 +27,7 @@ class Welcome extends React.Component {
   }
 
   componentDidMount() {
-    openCurrentRouteInPersistentPopup();
+    openCurrentRouteInPersistentTab();
     this.initLocal()
   }
   componentWillUnmount() {

--- a/src/popup/pages/Welcome/index.js
+++ b/src/popup/pages/Welcome/index.js
@@ -12,7 +12,7 @@ import {
 } from "../../../i18n";
 import { setLanguage } from "../../../reducers/appReducer";
 import { setWelcomeNextRoute } from "../../../reducers/cache";
-import { openCurrentRouteInPersistentTab } from '../../../utils/popup';
+import { openCurrentRouteInPersistentPopup } from '../../../utils/popup';
 import Button from "../../component/Button";
 import Select from "../../component/Select";
 import "./index.scss";
@@ -27,7 +27,7 @@ class Welcome extends React.Component {
   }
 
   componentDidMount() {
-    openCurrentRouteInPersistentTab();
+    openCurrentRouteInPersistentPopup();
     this.initLocal()
   }
   componentWillUnmount() {

--- a/src/popup/pages/Welcome/index.js
+++ b/src/popup/pages/Welcome/index.js
@@ -12,6 +12,7 @@ import {
 } from "../../../i18n";
 import { setLanguage } from "../../../reducers/appReducer";
 import { setWelcomeNextRoute } from "../../../reducers/cache";
+import { openCurrentRouteInPersistentPopup } from '../../../utils/popup';
 import Button from "../../component/Button";
 import Select from "../../component/Select";
 import "./index.scss";
@@ -26,6 +27,7 @@ class Welcome extends React.Component {
   }
 
   componentDidMount() {
+    openCurrentRouteInPersistentPopup();
     this.initLocal()
   }
   componentWillUnmount() {

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -1,6 +1,7 @@
 import extension from 'extensionizer'
 import { QUERY_TAB_TYPE } from '../constant/specifyType';
-import { getActiveTab } from './commonMsg';
+import { sendMsg, getActiveTab } from './commonMsg';
+import { WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP } from "../constant/types";
 
 const PopupSize = {
   width: 375,
@@ -165,14 +166,21 @@ export function fitPopupWindow() {
 
 // Opens current page in a popup window, so that it doesn't close when switching
 // to other windows (e.g. password manager).
-export async function openCurrentRouteInPersistentPopup() {
+export function openCurrentRouteInPersistentPopup() {
   const url = new URL(window.location);
   if (!url.searchParams.has('persistentPopup')) {
     url.searchParams.set('persistentPopup', '1');
-    await openPopupWindow(url.href, 'persistentPopup', undefined, {
-      left: window.screenLeft,
-      top: window.screenTop,
-    });
+
+    // Call openPopupWindow through background script, so lastWindowIds isn't
+    // lost, and popup is reused if called multiple times.
+    sendMsg({
+      action: WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP,
+      payload: {
+        left: window.screenLeft,
+        top: window.screenTop,
+        route: url.pathname + url.search + url.hash,
+      },
+    }, () => {});
     window.close();
   }
 }

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -171,6 +171,10 @@ export function openCurrentRouteInPersistentPopup() {
   if (!url.searchParams.has('persistentPopup')) {
     url.searchParams.set('persistentPopup', '1');
 
+    // Added random number because images were disappearing after
+    // opening Welcome page popup twice, after window.close().
+    url.searchParams.set('fixImagesDisappearing', '' + Math.random());
+
     // Call openPopupWindow through background script, so lastWindowIds isn't
     // lost, and popup is reused if called multiple times.
     sendMsg({

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -1,6 +1,6 @@
 import extension from 'extensionizer'
 import { QUERY_TAB_TYPE } from '../constant/specifyType';
-import { getActiveTab } from './commonMsg';
+import { getActiveTab, openTab } from './commonMsg';
 
 const PopupSize = {
   width: 375,
@@ -163,16 +163,13 @@ export function fitPopupWindow() {
   window.resizeTo(PopupSize.width + gap.width, PopupSize.height + gap.height);
 }
 
-// Opens current page in a popup window, so that it doesn't close when switching
+// Opens current page in a tab, so that it doesn't close when switching
 // to other windows (e.g. password manager).
-export async function openCurrentRouteInPersistentPopup() {
+export function openCurrentRouteInPersistentTab() {
   const url = new URL(window.location);
-  if (!url.searchParams.has('persistentPopup')) {
-    url.searchParams.set('persistentPopup', '1');
-    await openPopupWindow(url.href, 'persistentPopup', undefined, {
-      left: window.screenLeft,
-      top: window.screenTop,
-    });
+  if (!url.searchParams.has('persistentTab')) {
+    url.searchParams.set('persistentTab', '1');
+    openTab(url.href);
     window.close();
   }
 }

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -163,3 +163,16 @@ export function fitPopupWindow() {
   window.resizeTo(PopupSize.width + gap.width, PopupSize.height + gap.height);
 }
 
+// Opens current page in a popup window, so that it doesn't close when switching
+// to other windows (e.g. password manager).
+export async function openCurrentRouteInPersistentPopup() {
+  const url = new URL(window.location);
+  if (!url.searchParams.has('persistentPopup')) {
+    url.searchParams.set('persistentPopup', '1');
+    await openPopupWindow(url.href, 'persistentPopup', undefined, {
+      left: window.screenLeft,
+      top: window.screenTop,
+    });
+    window.close();
+  }
+}

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -1,6 +1,6 @@
 import extension from 'extensionizer'
 import { QUERY_TAB_TYPE } from '../constant/specifyType';
-import { getActiveTab, openTab } from './commonMsg';
+import { getActiveTab } from './commonMsg';
 
 const PopupSize = {
   width: 375,
@@ -163,13 +163,16 @@ export function fitPopupWindow() {
   window.resizeTo(PopupSize.width + gap.width, PopupSize.height + gap.height);
 }
 
-// Opens current page in a tab, so that it doesn't close when switching
+// Opens current page in a popup window, so that it doesn't close when switching
 // to other windows (e.g. password manager).
-export function openCurrentRouteInPersistentTab() {
+export async function openCurrentRouteInPersistentPopup() {
   const url = new URL(window.location);
-  if (!url.searchParams.has('persistentTab')) {
-    url.searchParams.set('persistentTab', '1');
-    openTab(url.href);
+  if (!url.searchParams.has('persistentPopup')) {
+    url.searchParams.set('persistentPopup', '1');
+    await openPopupWindow(url.href, 'persistentPopup', undefined, {
+      left: window.screenLeft,
+      top: window.screenTop,
+    });
     window.close();
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,10 +66,7 @@ module.exports = (env, argv) => {
             {
               loader: "url-loader",
               options: {
-                // Removed `limit: 8192,` because images were disappearing after
-                // opening Welcome page popup twice, after window.close() in
-                // openCurrentRouteInPersistentPopup. Without limit, all images
-                // are inlined as base64 data URLs.
+                limit: 8192,
               },
             },
           ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,10 @@ module.exports = (env, argv) => {
             {
               loader: "url-loader",
               options: {
-                limit: 8192,
+                // Removed `limit: 8192,` because images were disappearing after
+                // opening Welcome page popup twice, after window.close() in
+                // openCurrentRouteInPersistentPopup. Without limit, all images
+                // are inlined as base64 data URLs.
               },
             },
           ],


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-ext/issues/12

This became complicated.

I tried simply calling `openTab(url.href);` (when user clicks extension to create a wallet) and it caused images to disappear if called multiple times (creating multiple tabs). It also happens if I create a persistent popup instead of creating tabs. I don't know why, probably a chrome bug.

As a workaround I made all images inlined now