### PR TITLE
ExtDappService: urlencode query parameters

### DIFF
--- a/src/background/service/ExtDappService.js
+++ b/src/background/service/ExtDappService.js
@@ -103,9 +103,9 @@ class ExtDappService {
         isUnlocked = isUnlocked ? 1 : 0
         let siteUrl = origin
         let icon = await this.getWebIcon(origin)
-        this.popupId = await this.dappOpenPopWindow('./popup.html#/approve_page?isUnlocked=' + isUnlocked
-          + "&siteUrl=" + siteUrl
-          + "&siteIcon=" + icon,
+        this.popupId = await this.dappOpenPopWindow('./popup.html#/approve_page?isUnlocked=' + encodeURIComponent(isUnlocked)
+          + "&siteUrl=" + encodeURIComponent(siteUrl)
+          + "&siteIcon=" + encodeURIComponent(icon),
           windowId.approve_page, "dapp")
         this.setBadgeContent("approve_page", BADGE_ADD)
       } catch (error) {
@@ -199,10 +199,10 @@ class ExtDappService {
         let message = params.message
         let address = params.address
 
-        await this.dappOpenPopWindow('./popup.html#/request_sign?isUnlocked=' + isUnlocked
-          + "&siteUrl=" + siteUrl
-          + "&context=" + context + "&message=" + message + "&address=" + address
-          + "&siteIcon=" + icon,
+        await this.dappOpenPopWindow('./popup.html#/request_sign?isUnlocked=' + encodeURIComponent(isUnlocked)
+          + "&siteUrl=" + encodeURIComponent(siteUrl)
+          + "&context=" + encodeURIComponent(context) + "&message=" + encodeURIComponent(message) + "&address=" + encodeURIComponent(address)
+          + "&siteIcon=" + encodeURIComponent(icon),
           windowId.request_sign, "dapp")
         this.setBadgeContent("request_sign", BADGE_ADD)
       } catch (error) {


### PR DESCRIPTION
fixes #34 

_within_ the file I've liberally added `encodeURIComponent` to these parts where it constructs a query string (albeit in the hash of the URL).

I had found other occurrences of `=" +` in the codebase, but they seem to be for bech32 addresses (can't contain `&`) and hard-coded numbers. I've done the conservative thing there of not touching them.