### PR TITLE
AccountIcon: new addressToNumber

### DIFF
--- a/src/popup/component/AccountIcon/index.js
+++ b/src/popup/component/AccountIcon/index.js
@@ -1,4 +1,5 @@
 import jazzicon from '@metamask/jazzicon'
+import * as oasis from '@oasisprotocol/client'
 import React, { createRef, PureComponent } from 'react'
 
 export default class AccountIcon extends PureComponent {
@@ -16,20 +17,15 @@ export default class AccountIcon extends PureComponent {
         const identicon = jazzicon(diameter, numericRepresentation)
         return identicon
     }
-    str2hex = (str) => {
-        if (str === "") {
-            return "";
-        }
-        var arr = [];
-        arr.push("0x");
-        for (var i = 0; i < str.length; i++) {
-            arr.push(str.charCodeAt(i).toString(16));
-        }
-        return arr.join('');
-    }
     addressToNumber = (address) => {
-        const addr = address.slice(7, 16)
-        const seed = parseInt(this.str2hex(addr), 16)
+        const addressU8 = oasis.staking.addressFromBech32(address)
+        // Use bytes from the end for a seed.
+        // jazzicon internally uses mersenne-twister, which accepts a 32-bit seed.
+        const seed =
+            addressU8[20] |
+            addressU8[19] << 8 |
+            addressU8[18] << 16 |
+            addressU8[17] << 24
         return seed
     }
 


### PR DESCRIPTION
previously this function would read 9 characters from the middle of the bech32 address

```
oasis1x[xxxxxxxxx]xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

take the charCodeAt and convert to hex

```
0xYYYYYYYYYYYYYYYYYY
```

that being 18 digits long or 72 bits

it would parse this into a number represented in a double precision float, which I understand would have a 53-bit mantissa

```
0bZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
becomes
0bZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ0000000000000000000
```

for the seed, integer math would then take the bottom 32 bits of that

```
0bZZZZZZZZZZZZZ0000000000000000000
```

getting approximately 13 not-always-zero bits

these not-always-zero bits come from base-32 letters, so about 5 bits of entropy per 8 bits

so the icon would be generated from ~8.1 bits of entropy

---

this new addressToNumber uses 32 bits from the end of the binary address (i.e. excluding the version)

fixes #57