### PR TITLE
popup -> background messages per-origin scope

### DIFF
--- a/src/background/service/ExtDappService.js
+++ b/src/background/service/ExtDappService.js
@@ -175,6 +175,7 @@ class ExtDappService {
         async function onMessage(message, sender, sendResponse) {
           const { action, payload } = message;
           if (action === DAPP_ACTION_SEND_TRANSACTION) {
+            if (payload.resultOrigin !== site) return;
             extension.runtime.onMessage.removeListener(onMessage)
             that.setBadgeContent("request_sign", BADGE_MINUS)
             await closePopupWindow(windowId.request_sign)

--- a/src/background/service/ExtDappService.js
+++ b/src/background/service/ExtDappService.js
@@ -57,6 +57,7 @@ class ExtDappService {
           const { action, payload } = message;
           switch (action) {
             case DAPP_ACTION_GET_ACCOUNT:
+              if (payload.resultOrigin !== origin) break;
               extension.runtime.onMessage.removeListener(onMessage)
               await closePopupWindow(windowId.approve_page)
               that.setBadgeContent("approve_page", BADGE_MINUS)
@@ -88,6 +89,7 @@ class ExtDappService {
               sendResponse()
               break;
             case DAPP_ACTION_CLOSE_WINDOW:
+              if (payload.resultOrigin !== origin) break;
               extension.runtime.onMessage.removeListener(onMessage)
               resolve(payload.account)
               await closePopupWindow(payload.page)

--- a/src/popup/pages/ApprovePage/index.js
+++ b/src/popup/pages/ApprovePage/index.js
@@ -101,8 +101,9 @@ class ApprovePage extends React.Component {
               action: DAPP_ACTION_GET_ACCOUNT,
               payload:{
                 selectAccount:[],
-                currentAddress:currentAccount.address
-              }
+                currentAddress:currentAccount.address,
+                resultOrigin: this.getParams().siteUrl,
+              },
             }, async (params) => {
               this.goToHome()
              })
@@ -118,7 +119,8 @@ class ApprovePage extends React.Component {
                 action: DAPP_ACTION_GET_ACCOUNT,
                 payload: {
                   selectAccount,
-                  currentAddress:currentAccount.address
+                  currentAddress:currentAccount.address,
+                  resultOrigin: this.getParams().siteUrl,
                  },
               }, (params) => {
                 this.goToHome()
@@ -150,7 +152,8 @@ class ApprovePage extends React.Component {
           action: DAPP_ACTION_CLOSE_WINDOW,
           payload: {
             page: "approve_page",
-            account: approveAccount
+            account: approveAccount,
+            resultOrigin: this.getParams().siteUrl,
           },
         }, (params) => { })
       } else {

--- a/src/popup/pages/SignTransaction/index.js
+++ b/src/popup/pages/SignTransaction/index.js
@@ -122,7 +122,8 @@ class SignTransaction extends React.Component {
           payload: {
             isConfirmed: true,
             ledgerSignatureHex: signatureHex,
-            ledgerWallet: true
+            ledgerWallet: true,
+            resultOrigin: winParams.siteUrl,
           },
         }, async (params) => {
           this.goToHome()
@@ -134,7 +135,8 @@ class SignTransaction extends React.Component {
           payload: {
             isConfirmed: true,
             ledgerWallet: true,
-            ledgerError: error
+            ledgerError: error,
+            resultOrigin: this.getParams().siteUrl,
           },
         }, async (params) => {
           this.goToHome()
@@ -143,7 +145,10 @@ class SignTransaction extends React.Component {
     } else {
       sendMsg({
         action: DAPP_ACTION_SEND_TRANSACTION,
-        payload: { isConfirmed: true },
+        payload: {
+          isConfirmed: true,
+          resultOrigin: this.getParams().siteUrl,
+        },
       }, async (params) => {
         this.goToHome()
       })
@@ -165,7 +170,10 @@ class SignTransaction extends React.Component {
           onClick={() => {
             sendMsg({
               action: DAPP_ACTION_SEND_TRANSACTION,
-              payload: { isConfirmed: false },
+              payload: {
+                isConfirmed: false,
+                resultOrigin: this.getParams().siteUrl,
+              },
             }, async (params) => {
               this.goToHome()
             })


### PR DESCRIPTION
fixes #32 

previously, if multiple sites would ask for stuff at the same time, an answer from one site's popup (e.g. selecting keys or signing transaction) would be delivered to all sites that were asking

this bandaid makes it so that it's only delivered to one site. it would good to narrow it down further to only respond to a single request at a time, in case some wild dapp asks for multiple things all at once.

but for now, at least we can stop accidentally revealing the user's identity to the wrong sites