### PR TITLE
utils: Simplify isNumber's regular expression

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -108,7 +108,7 @@ export function urlValid(url) {
  * @param includeE Whether to include scientific notation
  */
 export function isNumber(n, includeE = false) {
-    let isNum = !!String(n).match(/^\d+(?:\.\d*)?$/);
+    let isNum = !!String(n).match(/^\d+(\.\d*)?$/);
     if (!isNum && includeE) {
         return !!String(n).match(/^\d+e(-)?\d+$/);
     }


### PR DESCRIPTION
Drop the non-capturing group syntax since it is not used later.

Related to #70.