### PR TITLE
Update commission rate label

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -152,7 +152,7 @@
 
 
     "inputNetAddress":"Please enter validator node address",
-    "stakeCommission":"Rates",
+    "stakeCommission":"Commission",
     "nodeTotalStake":"Total Stake",
     "nodeOtherStake":"Other",
     "nodeSelfStake":"Self",


### PR DESCRIPTION
This PR updates the label for a validator's commission rate from `Rates` to `Commission`.

Old:
![image](https://user-images.githubusercontent.com/2524122/132440887-00a9ba6c-6827-4180-a7c4-ea04c10b06fe.png)

New:
![image](https://user-images.githubusercontent.com/2524122/132440707-fa5b6e3f-09e7-4eb6-a8d8-40ab3175d09d.png)
