### PR TITLE
popup: repurpose fitPopupWindow

### DIFF
--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -148,18 +148,6 @@ export function fitPopupWindow() {
     height: window.outerHeight - window.innerHeight,
   };
 
-  if (extension.windows) {
-    extension.windows.getCurrent().then((window) => {
-      if (window?.id != null) {
-        extension.windows.update(window.id, {
-          width: PopupSize.width + gap.width,
-          height: PopupSize.height + gap.height,
-        });
-      }
-    });
-    return;
-  }
-
   window.resizeTo(PopupSize.width + gap.width, PopupSize.height + gap.height);
 }
 
@@ -185,5 +173,7 @@ export function openCurrentRouteInPersistentPopup() {
       },
     }, () => {});
     window.close();
+  } else {
+    fitPopupWindow();
   }
 }


### PR DESCRIPTION
fixes #120

It looked like fixing all layouts to support a smaller size (due to the window frame) would have been much more work, which we don't want to let that block the first release.

This makes the popup enlarge itself to fit the original UI.

My reading of the Chrome extension API https://developer.chrome.com/docs/extensions/reference/windows/#method-create unfortunately concludes that there is no way to open the popup at the right size in the first place, because you can only specify the "outer" width/height, and it's not known how thick the frame will be.

Within the code there's a `fitPopupWindow` that seems to serve this purpose already. This function isn't currently in use. I've repurposed it for use with `openCurrentRouteInPersistentPopup`.

A screenshot of the larger window:

![image](https://user-images.githubusercontent.com/38229038/132566123-ac2497d0-3bf6-46f1-a568-832b6214437e.png)

see how it's 383 x 629 <- from 375 x 600
