### PR TITLE
AboutUs: move and expand "Powered by" line

### DIFF
--- a/src/popup/pages/AboutUs/index.js
+++ b/src/popup/pages/AboutUs/index.js
@@ -83,6 +83,9 @@ class AboutUs extends React.Component {
           {this.renderTopInfo()}
           {this.renderWalletDetail()}
         </div>
+        <div className="about-tip-container">
+          <p className="about-tip">Powered by Bit Cat and Simply VC</p>
+        </div>
       </CustomView>)
   }
 }

--- a/src/popup/pages/AboutUs/index.scss
+++ b/src/popup/pages/AboutUs/index.scss
@@ -79,3 +79,15 @@
 .wallet-detail-container {
     margin-top: 60px;
 }
+
+.about-tip-container {
+    bottom: 20px;
+    position: absolute;
+    text-align: center;
+    width: 100%;
+}
+
+.about-tip {
+    color: #7080b5;
+    font-size: $font-size-desc;
+}

--- a/src/popup/pages/Lock/index.js
+++ b/src/popup/pages/Lock/index.js
@@ -238,9 +238,6 @@ class LockPage extends React.Component {
             <div className={"restore-bottom-container"}>
                 <p className="restore-bottom" onClick={this.onClickRestore}>{getLanguage('resetWallet')}</p>
             </div>
-            <div className={"lock-bottom-container"}>
-                <p className="lock-bottom" >Powered by Bit Cat</p>
-            </div>
             <form onSubmit={this.onSubmit}>
                 {this.renderChangeModal()}
             </form>

--- a/src/popup/pages/Lock/index.scss
+++ b/src/popup/pages/Lock/index.scss
@@ -21,21 +21,6 @@
     margin-top: 30px;
     text-align: center;
 }
-.lock-bottom-container {
-    position: absolute;
-    text-align: center;
-    margin-left: 0px;
-    width: 100%;
-    bottom: 20px;
-    margin: auto;
-    left: 0;
-    right: 0;
-}
-.lock-bottom {
-    margin: 0;
-    font-size: $font-size-desc;
-    color: #b9b9b9;
-}
 .lock-home-logo {
     width: 75px;
     height: 75px;

--- a/src/popup/pages/Welcome/index.js
+++ b/src/popup/pages/Welcome/index.js
@@ -102,9 +102,6 @@ class Welcome extends React.Component {
         >
         </Button>
       </div>
-      <div className={'welcome-tip-container'}>
-        <p className="bottomTip" >Powered by Bit Cat</p>
-      </div>
     </div>)
   }
 }

--- a/src/popup/pages/Welcome/index.scss
+++ b/src/popup/pages/Welcome/index.scss
@@ -6,22 +6,6 @@
   background: url("../../../assets/images/welcome_bg.png");
   background-size: 100% 100%;
 }
-.welcome-tip-container {
-  position: absolute;
-  bottom: 27px;
-  margin: auto;
-  width: 100%;
-  left: 0;
-  right: 0;
-  text-align: center;
-}
-.bottomTip {
-  font-size: $font-size-desc;
-
-  font-weight: 400;
-  color: #7080b5;
-  line-height: 17px;
-}
 
 .welcome-button-container {
   margin-top: 200px;


### PR DESCRIPTION
no issue filed, but I am to understand that the teams involved agreed to:

1. move the "Powered by ..." from the welcome and lock screens to the about screen
2. add Simply VC to this line

a screenshot of the new line

![image](https://user-images.githubusercontent.com/38229038/132568974-6b77d6e2-d690-456a-8d04-5a626e0290dd.png)
