### PR TITLE
keep optimization.splitChunks in development

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,7 +34,7 @@
   ],
   "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.oasisscan.com https://www.oasisscan.com https://testnet.oasisscan.com https://grpc-mainnet.oasisscan.com https://grpc.oasis.dev https://grpc-testnet.oasisscan.com https://testnet.grpc.oasis.dev; frame-ancestors 'self' https: http://localhost:* http://127.0.0.1:*; img-src 'self' data: https: http://localhost:* http://127.0.0.1:*; base-uri 'self'; manifest-src 'self';",
   "background": {
-    "scripts": ["background.js"],
+    "scripts": ["common.js", "background.js"],
     "persistent": true
   },
   "web_accessible_resources": [

--- a/public/oasis-xu-frame.html
+++ b/public/oasis-xu-frame.html
@@ -1,2 +1,3 @@
 <!doctype html>
+<script src="./common.js"></script>
 <script src="./xuframe.js"></script>

--- a/public/static/popup.html
+++ b/public/static/popup.html
@@ -7,6 +7,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script src="./common.js"></script>
     <script src="./popup.js"></script>
   </body>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,9 +95,7 @@ module.exports = (env, argv) => {
   };
   if (isDev) {
     config.devtool = 'cheap-module-source-map';
-    config.optimization = {
-      minimize: false,
-    };
+    config.optimization.minimize = false;
   }
   return config;
 }


### PR DESCRIPTION
It's less complicated this way, having a common.js bundle created
the same for both production and development.

Also, we'd need this to test in Firefox during development; as I am
informed that the code splitting is meant to satisfy Firefox's
script size limit.

fixes #148 