### PR TITLE
pages/Wallet: don't show Allow transactions

### DIFF
--- a/src/popup/pages/Wallet/index.js
+++ b/src/popup/pages/Wallet/index.js
@@ -512,12 +512,28 @@ class Wallet extends React.Component {
     if (item.showExplorer) {
       return this.renderListExplorer(index)
     }
-    let isReceive = true
+    let isReceive
     let showAddress = item.to
-    if (item.method === TRANSACTION_TYPE.Transfer) {
-      isReceive = item.to.toLowerCase() === this.props.currentAccount.address.toLowerCase()
-    } else if (item.method === TRANSACTION_TYPE.AddEscrow) {
-      isReceive = false
+    switch (item.method) {
+      case TRANSACTION_TYPE.Transfer:
+        if (item.to.toLowerCase() === this.props.currentAccount.address.toLowerCase()) {
+          isReceive = true
+          // TODO: do we want to change showAddress to item.from?
+        } else {
+          isReceive = false
+        }
+        break
+      case TRANSACTION_TYPE.AddEscrow:
+        isReceive = false
+        break
+      case TRANSACTION_TYPE.ReclaimEscrow:
+        isReceive = true
+        break
+      default:
+        // For other transaction types that don't affect the balance (e.g. Allow), we're not
+        // showing them in this abbreviated list. Users can still, however, view them on a block
+        // explorer such as OASISSCAN.
+        return <></>
     }
     showAddress = addressSlice(showAddress, 8)
     let amount = item.amount

--- a/src/popup/pages/Wallet/index.js
+++ b/src/popup/pages/Wallet/index.js
@@ -518,7 +518,9 @@ class Wallet extends React.Component {
       case TRANSACTION_TYPE.Transfer:
         if (item.to.toLowerCase() === this.props.currentAccount.address.toLowerCase()) {
           isReceive = true
-          // TODO: do we want to change showAddress to item.from?
+          // For transactions we receive, show the sender's address instead of our own.
+          // Our own address is shown nearby already.
+          showAddress = item.from
         } else {
           isReceive = false
         }


### PR DESCRIPTION
These don't affect the balance, so we'll not show them in this particular transaction list.

With this PR, we only show transfer (to/from), escrow, and reclaim escrow