### PR TITLE
v1.0.0 release candidate

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,7 +27,7 @@ export const LOCK_TIME = 5 * 60
 /**
  * Extension's version.
  */
-export const VERSION_CONFIG = "0.1.0"
+export const VERSION_CONFIG = "1.0.0"
 
 /**
  * Default language.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.1.0
+
+Spotlight change:
+
+- Initial release!
+  Welcome to the official browser extension wallet.
+
+New features:
+
+- ADR-0008 mnemonic-backed accounts.
+- Ledger accounts.
+- Consensus layer transfers.
+- Consensus layer staking.
+- DApp connectivity.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.0.0
+
+Spotlight change:
+
+- You can now deposit and withdraw into/from select ParaTimes, starting with Oasis's Cipher and
+  Emerald.
+
+New features:
+
+- We now support the upcoming version 2.x.x of the Oasis app on Ledger.
+
+Bug fixes:
+
+- Stopped the password entry field from erasing spaces between words
+  ([#158](https://github.com/oasisprotocol/oasis-wallet-ext/issues/158)).
+
+Little things:
+
+- Some links in the About page are updated.
+- Transfers to your account in the transaction history list now show the address that sent it.
+- The transaction details page now shows the "From" line before the "To" line.
+
 ## 0.1.0
 
 Spotlight change:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oasis-wallet",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "build": "webpack --mode production",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "__MSG_appName__",
   "description": "__MSG_appDescription__",
   "manifest_version": 2,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "default_locale": "en",
   "icons": {
     "16": "img/oasis.png",


### PR DESCRIPTION
note: this is not v1. this is a release candidate, which I'm assigning v1.0.0. chrome doesn't allow an `-rc1` version suffix so let's just use v1.0.0 to mean rc1, v1.0.1 to mean rc2, etc., and eventually v1.0.x will be the real release, which we can tag.

also this is not really v1.0.0 either, until this gets merged

`yarn buildProd`: 
[oasis-wallet-189-rc1.zip](https://github.com/oasisprotocol/oasis-wallet-ext/files/7732284/oasis-wallet-189-rc1.zip)