### PR TITLE
docs: add release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Change Log
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ yarn test
 yarn buildProd
 ```
 
-## Preparing a Release
+## Preparing a Production Release Build
 
 ```sh
 VERSION=<VERSION>
@@ -108,6 +108,9 @@ yarn install --frozen-lockfile
 yarn buildProd
 zip -r oasis-wallet-$VERSION-$(git rev-parse --short HEAD).zip dist/
 ```
+
+If you're actually making a new release, follow the applicable steps in the
+[release process doc](docs/release-process.md)
 
 ## LICENSE
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,102 @@
+# Release Process
+
+## Determine the New Version
+Extension versions may not have suffixes like "-rc1".
+We are incrementing patch versions to differentiate release candidate builds.
+
+For example, the 1.0 release will start with a build at version 1.0.0.
+Version 1.0.0 is, at first, a release candidate.
+If changes are needed, we move to the next build at version 1.0.1.
+Version 1.0.1 is also a release candidate at first.
+If no changes are needed, 1.0.1 becomes the first public release of 1.0.
+
+## Set the New Version Throughout
+You must update:
+
+- `config.js`
+- `package.json`
+- `public/manifest.json`
+
+## Add a Change Log Section
+Here's the [Change Log](../CHANGELOG.md).
+If there is an "Unreleased changes" section, rename it to the new version.
+Do not include a "v" prefix in the heading.
+
+Add any other user-facing changes since the last release that aren't entered.
+Suggested sections:
+
+- Breaking changes
+- New features
+- Bug fixes
+- Little things
+- Documentation changes
+
+Items may include a link to GitHub issues if there is a relevant one, e.g. in bug fixes.
+We especially encourage linking externally reported issues.
+
+If you feel like it, move one Change Log item to a section on top titled "Spotlight change".
+
+## Propose the New Version
+Open a pull request (PR) for the version changes and Change Log update, ideally separate from
+any other changes.
+
+When this PR gets merged into `master`, the chosen version permanently associated with the merge
+commit.
+
+## Prepare an Unsigned Archive
+Clean the output directory, build, and package:
+
+```sh
+VERSION=<VERSION>
+rm -rf dist/
+yarn install --frozen-lockfile
+yarn buildProd
+zip -r oasis-wallet-$VERSION.zip dist/
+```
+
+Note: The zip file has no Git commit hash.
+
+## Add a Pre-Release on GitHub
+Create a tag and create a
+[new release](https://github.com/oasisprotocol/oasis-wallet-ext/releases/new) on GitHub.
+
+Enter `Oasis Wallet <VERSION> Release Candidate` for the title.
+
+Our Change Log is a file under version control, so all we do is put the link in the description:
+
+```md
+See the [Change Log](CHANGELOG.md) for what's new in this release.
+
+_Note: This is an internal release candidate._
+```
+
+Add the unsigned archive as an asset.
+
+Check the box to indicate that this is a pre-release.
+
+## Submit Package for Review
+
+_This step is for our web store account admins._
+_Contact an admin if you don't have access._
+
+Go to [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole/),
+browse to the _Oasis Wallet_ item,
+select _Package_ in the side bar and
+choose _Upload new package_.
+
+## Update GitHub Pre-Release
+Change the title:
+
+```diff
+-Oasis Wallet <VERSION> Release Candidate
++Oasis Wallet <VERSION>
+```
+
+Change the description:
+
+```diff
+-_Note: This is an internal release candidate._
++_NOTE: These are developer builds. To download the **official builds**, go to [Chrome Web Store](https://chrome.google.com/webstore/detail/oasis-wallet/ppdadbejkmjnefldpcdjhnkpbjkikoip)._
+```
+
+Uncheck the pre-release box.


### PR DESCRIPTION
I found that Chrome wouldn't let me load an extension where the version is set to something like `1.0.0-rc1`, so we've come up with this thing where we'll use the patch number for release candidate builds leading up to a public release. This new document describes that.

[rendered](https://github.com/oasisprotocol/oasis-wallet-ext/blob/pro-wh/feature%2Fprocedures/docs/release-process.md)