### PR TITLE
fix(app): Allow users to select detail content as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Little things:
 - Popup is now wider.
 - Buttons to confirm wallet resetting are now red and no longer swapped.
 - Blocked Google Translate from translating displayed mnemonic.
+- Amounts displayed in the account information is now selectable.
 
 ## 1.0.0
 

--- a/src/popup/App.scss
+++ b/src/popup/App.scss
@@ -22,10 +22,7 @@ body {
 p {
   margin: 0;
   padding: 0;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
-  -ms-user-select: none;
+  user-select: none;
 }
 
 input,

--- a/src/popup/pages/Main/index.scss
+++ b/src/popup/pages/Main/index.scss
@@ -246,6 +246,7 @@ p {
   font-weight: 500;
   color: #2c3451;
   line-height: 14px;
+  user-select: text;
 }
 
 .tx-row-container {

--- a/src/popup/pages/Record/index.scss
+++ b/src/popup/pages/Record/index.scss
@@ -30,6 +30,7 @@
     color: #2c3451;
     line-height: 20px;
     width: 220px;
+    user-select: text;
 }
 
 .record-explorer-inner-container {


### PR DESCRIPTION
Fixes an issue where users could not select detail content as text, eg. the total wallet amount or the transaction record details.

![screenshot](https://user-images.githubusercontent.com/72995223/147850313-936019ba-205d-4491-a67c-ea4b1cfd777b.png)
