### PR TITLE
pages: unshow Oasis address for secp256k1 accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Little things:
 
 - The transaction review page now shows the "From" line before the "To" line.
 - The recovery page instructions now indicate that you can enter a 24-word mnemonic.
+- We no longer show the `oasis1...` address for Ethereum-compatible accounts.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased Changes
+
+Little things:
+
+- The transaction review page now shows the "From" line before the "To" line.
+- The recovery page instructions now indicate that you can enter a 24-word mnemonic.
+
 ## 1.0.0
 
 Spotlight change:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -18,7 +18,7 @@ You must update:
 
 ## Add a Change Log Section
 Here's the [Change Log](../CHANGELOG.md).
-If there is an "Unreleased changes" section, rename it to the new version.
+If there is an "Unreleased Changes" section, rename it to the new version.
 Do not include a "v" prefix in the heading.
 
 Add any other user-facing changes since the last release that aren't entered.

--- a/src/popup/pages/AccountInfo/index.js
+++ b/src/popup/pages/AccountInfo/index.js
@@ -238,6 +238,11 @@ class AccountInfo extends React.Component {
   render() {
     const { showSecurity,showDelete,showAddress,evmAddress } = this.state
     let title = showSecurity ? getLanguage('securityPassword') : getLanguage('accountInfo')
+    let addressInfo = evmAddress ? (
+      this.renderCommonShowItem(getLanguage("evmAddress"), evmAddress, ()=>this.copyAddress(evmAddress))
+    ) : (
+      this.renderCommonShowItem(getLanguage("accountAddress"), showAddress, ()=>this.copyAddress(this.state.account.address))
+    )
     return (
       <CustomView
         title={title}
@@ -245,8 +250,7 @@ class AccountInfo extends React.Component {
         {showSecurity ? <SecurityPwd onClickCheck={this.onClickCheck} action={SEC_DELETE_ACCOUNT} /> :
           <>
             <div className="account-info-container">
-              {this.renderCommonShowItem(getLanguage("accountAddress"), showAddress, ()=>this.copyAddress(this.state.account.address))}
-              {evmAddress && this.renderCommonShowItem(getLanguage("evmAddress"), evmAddress, ()=>this.copyAddress(evmAddress))}
+              {addressInfo}
               {this.renderCommonShowItem(getLanguage("accountName"), this.state.account.accountName, this.changeAccountName, true)}
 
               {this.renderExportPrivateKey()}

--- a/src/popup/pages/AccountManage/AccountItem.js
+++ b/src/popup/pages/AccountManage/AccountItem.js
@@ -60,8 +60,17 @@ class AccountItem extends Component {
     render() {
         const { item, showSelect, showImport, onClickAccount, goToAccountInfo, symbol, cacheAccount } = this.props
         let imgSource = showSelect ? select_account_ok : select_account_no
-        let showBalance = cacheAccount && cacheAccount.total || item.balance || this.state.balance
-        showBalance = showBalance + " " + symbol
+        let addressInfo
+        if (item.evmAddress) {
+            addressInfo = <p className={'account-item-address descAddress'}>{addressSlice(item.evmAddress)}</p>
+        } else {
+            let showBalance = cacheAccount && cacheAccount.total || item.balance || this.state.balance
+            showBalance = showBalance + " " + symbol
+            addressInfo = <>
+                <p className={"account-item-address"}>{addressSlice(item.address)}</p>
+                <p className={"account-item-address account-item-balance"}>{showBalance}</p>
+            </>
+        }
         return (
             <div onClick={() => onClickAccount && onClickAccount(item)}
                 className={"account-item-container click-cursor"}>
@@ -76,8 +85,7 @@ class AccountItem extends Component {
                             "account-item-type-observe": item.type === ACCOUNT_TYPE.WALLET_OBSERVE,
                         })}>{showImport}</p>
                     </div>
-                    <p className={"account-item-address"}>{addressSlice(item.address)}</p>
-                    {item.evmAddress ?<p className={'account-item-address descAddress'}>{addressSlice(item.evmAddress)}</p>: <p className={"account-item-address account-item-balance"}>{showBalance}</p>}
+                    {addressInfo}
                 </div>
                 <div className={"account-item-right"}>
                     <img

--- a/src/popup/pages/Wallet/index.js
+++ b/src/popup/pages/Wallet/index.js
@@ -446,14 +446,18 @@ class Wallet extends React.Component {
   }
   renderEvmWalletInfo =()=>{
     let { currentAccount } = this.props
+    let addressInfo = currentAccount.evmAddress ? (
+      <p className={"account-evm-address click-cursor"} onClick={()=>this.onClickAddress(currentAccount.evmAddress)}>{addressSlice(currentAccount.evmAddress)}</p>
+    ) : (
+      <p className="account-address click-cursor" onClick={()=>this.onClickAddress(currentAccount.address)}>{addressSlice(currentAccount.address)}</p>
+    )
     return (
       <div className="wallet-info">
       <div className="account-container">
         <div className={"account-container-top"}>
           <div>
             {this.renderAccountName()}
-            <p className="account-address click-cursor" onClick={()=>this.onClickAddress(currentAccount.address)}>{addressSlice(currentAccount.address)}</p>
-            {currentAccount.evmAddress && <p className={"account-evm-address click-cursor"} onClick={()=>this.onClickAddress(currentAccount.evmAddress)}>{addressSlice(currentAccount.evmAddress)}</p>}
+            {addressInfo}
           </div>
           <div className={'account-container-top-right'}>
             <div className="account-manager click-cursor"

--- a/src/popup/pages/Wallet/index.js
+++ b/src/popup/pages/Wallet/index.js
@@ -606,13 +606,20 @@ class Wallet extends React.Component {
   }
   render() {
     let { currentAccount } = this.props
+    let infoAndHistory = currentAccount.evmAddress ? (
+      this.renderEvmWalletInfo()
+    ) : (
+      <>
+        {this.renderWalletInfo()}
+        {this.renderHistory()}
+      </>
+    )
     return (
       <div className="wallet-page-container">
         <div className={"home-wallet-top-container"}>
           <WalletBar history={this.props.params.history} />
         </div>
-        {currentAccount.evmAddress ? this.renderEvmWalletInfo() : this.renderWalletInfo()}
-        {!currentAccount.evmAddress && this.renderHistory()}
+        {infoAndHistory}
         {this.renderChangeModal()}
         <Clock schemeEvent={() => { this.fetchData(this.props.currentAccount.address) }} />
       </div>


### PR DESCRIPTION
Accounts other than the ed25519 kind aren't usable on the consensus layer, and other paratimes aren't in widespread use with this wallet. With this change, we're no longer showing the Oasis address for non-ed25519 accounts so that people don't mistakenly enter them into a field that needs a consensus layer address.
