### PR TITLE
pages/Wallet: show runtime transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Little things:
 
 - The transaction review page now shows the "From" line before the "To" line.
 - The recovery page instructions now indicate that you can enter a 24-word mnemonic.
+- We no longer show the `oasis1...` address for Ethereum-compatible accounts.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased changes
+
+Little things:
+
+- The transaction review page now shows the "From" line before the "To" line.
+- The recovery page instructions now indicate that you can enter a 24-word mnemonic.
+
 ## 1.0.0
 
 Spotlight change:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+New features:
+
+- Select ParaTime transactions, including Emerald deposit and withdraw, now show up in your
+  consensus account's transaction history.
+
 Little things:
 
 - The transaction review page now shows the "From" line before the "To" line.

--- a/src/background/api/index.js
+++ b/src/background/api/index.js
@@ -24,12 +24,31 @@ export async function getBalance(address) {
  */
 export async function getTransactionList(address) {
   let url = "/chain/transactions?address=" + address + "&size=" + TX_LIST_LENGTH
-  let txList = await commonFetch(url).catch(() => { })
-  if (txList && txList.code === 0) {
-    return txList.data
-  } else {
+  let txList;
+  try {
+    txList = await commonFetch(url)
+  } catch(e) {
+    console.error('fetching runtime transaction list', url, e)
     return []
   }
+  return txList.data
+}
+
+/**
+ * get runtime tx list
+ * @param {*} address
+ * @returns
+ */
+export async function getRuntimeTransactionList(address) {
+  let url = "/chain/transactions?address=" + address + "&runtime=true&size=" + TX_LIST_LENGTH
+  let txList;
+  try {
+    txList = await commonFetch(url)
+  } catch(e) {
+    console.error('fetching runtime transaction list', url, e)
+    return []
+  }
+  return txList.data
 }
 
 /**

--- a/src/popup/pages/AccountInfo/index.js
+++ b/src/popup/pages/AccountInfo/index.js
@@ -245,7 +245,7 @@ class AccountInfo extends React.Component {
         {showSecurity ? <SecurityPwd onClickCheck={this.onClickCheck} action={SEC_DELETE_ACCOUNT} /> :
           <>
             <div className="account-info-container">
-              {this.renderCommonShowItem(getLanguage("accountAddress"), showAddress, ()=>this.copyAddress(this.state.account.address))}
+              {!evmAddress && this.renderCommonShowItem(getLanguage("accountAddress"), showAddress, ()=>this.copyAddress(this.state.account.address))}
               {evmAddress && this.renderCommonShowItem(getLanguage("evmAddress"), evmAddress, ()=>this.copyAddress(evmAddress))}
               {this.renderCommonShowItem(getLanguage("accountName"), this.state.account.accountName, this.changeAccountName, true)}
 

--- a/src/popup/pages/AccountManage/AccountItem.js
+++ b/src/popup/pages/AccountManage/AccountItem.js
@@ -76,7 +76,7 @@ class AccountItem extends Component {
                             "account-item-type-observe": item.type === ACCOUNT_TYPE.WALLET_OBSERVE,
                         })}>{showImport}</p>
                     </div>
-                    <p className={"account-item-address"}>{addressSlice(item.address)}</p>
+                    {!item.evmAddress && <p className={"account-item-address"}>{addressSlice(item.address)}</p>}
                     {item.evmAddress ?<p className={'account-item-address descAddress'}>{addressSlice(item.evmAddress)}</p>: <p className={"account-item-address account-item-balance"}>{showBalance}</p>}
                 </div>
                 <div className={"account-item-right"}>

--- a/src/popup/pages/Wallet/index.js
+++ b/src/popup/pages/Wallet/index.js
@@ -452,7 +452,7 @@ class Wallet extends React.Component {
         <div className={"account-container-top"}>
           <div>
             {this.renderAccountName()}
-            <p className="account-address click-cursor" onClick={()=>this.onClickAddress(currentAccount.address)}>{addressSlice(currentAccount.address)}</p>
+            {!currentAccount.evmAddress && <p className="account-address click-cursor" onClick={()=>this.onClickAddress(currentAccount.address)}>{addressSlice(currentAccount.address)}</p>}
             {currentAccount.evmAddress && <p className={"account-evm-address click-cursor"} onClick={()=>this.onClickAddress(currentAccount.evmAddress)}>{addressSlice(currentAccount.evmAddress)}</p>}
           </div>
           <div className={'account-container-top-right'}>

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -329,3 +329,10 @@ export function isEvmAddress(address){
     }
     return false
 }
+
+export function mergeTxLists(lists){
+    // It should suffice to sort by timestamp, which in honest operation will be monotonic.
+    let result = lists.flat();
+    result.sort((a, b) => b.timestamp - a.timestamp);
+    return result;
+}


### PR DESCRIPTION
Oasis Scan recently added an API to get select runtime transactions. I had gotten started on adding it to the wallet UI, but Bit Cat said they would handle it :pray:. Here's what I had going though.

![image](https://user-images.githubusercontent.com/38229038/147992913-6221e593-fab0-4d20-a6d5-33ca348ea712.png)
