### PR TITLE
unbreak paratime withdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+New features:
+
+- ParaTime withdrawals now automatically set the fee that will soon be required on Emerald
+  (0.0005 ROSE/TEST)
+
 Little things:
 
 - The advanced fee options now indicates the unit for the amount (nano ROSE/TEST).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Bug fixes:
 
 - Brought ParaTime transaction hashing in sync with block explorer.
+- Emerald transactions had mistakenly used a lower fee than configured, when using the advanced fee
+  options. This is corrected.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug fixes:
 - Brought ParaTime transaction hashing in sync with block explorer.
 - Emerald transactions had mistakenly used a lower fee than configured, when using the advanced fee
   options. This is corrected.
+- Corrected how the total amount+fee is calculated when checking if you have enough funds for a
+  transaction.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 New features:
 
 - ParaTime withdrawals now automatically set the fee that will soon be required on Emerald
-  (0.0005 ROSE/TEST)
+  (0.00015 ROSE/TEST)
 
 Little things:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+Little things:
+
+- The advanced fee options now indicates the unit for the amount (nano ROSE/TEST).
+
 Bug fixes:
 
 - Brought ParaTime transaction hashing in sync with block explorer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unrelease changes
+## Unreleased changes
 
 Bug fixes:
 

--- a/src/background/api/txHelper.js
+++ b/src/background/api/txHelper.js
@@ -299,7 +299,9 @@ export async function buildParatimeTxBody(params, wrapper) {
         oasis.quantity.fromBigInt(amount),
         oasisRT.token.NATIVE_DENOMINATION
     ]);
-    let feeAmount  = params.feeAmount||0
+    // Fee amount idiosyncrasy: UI presents it in 1e-9 always, regardless of paratime setting.
+    let feeAmountDecimal = new BigNumber(10).pow(cointypes.decimals)
+    let feeAmount  = new BigNumber(params.feeAmount||0).multipliedBy(decimal).dividedBy(feeAmountDecimal).toFixed()
     feeAmount = BigInt(feeAmount)
     const FEE_FREE =([
         oasis.quantity.fromBigInt(feeAmount),

--- a/src/background/api/txHelper.js
+++ b/src/background/api/txHelper.js
@@ -309,7 +309,7 @@ export async function buildParatimeTxBody(params, wrapper) {
     ]);
     feeAmount  = FEE_FREE
     // Use default if feeGas is "" or 0 (0 is illegal in send page)
-    let feeGas = params.feeGas||50000
+    let feeGas = params.feeGas||15000
     feeGas = BigInt(feeGas)
     let consensusChainContext = await getChainContext(RETRY_TIME)
     let txWrapper

--- a/src/popup/pages/Send/index.js
+++ b/src/popup/pages/Send/index.js
@@ -90,6 +90,7 @@ class SendPage extends React.Component {
     let runtimeType = params.accountType||""
     let runtimeDecimals = params.decimals||cointypes.decimals
     let isWithdraw = false
+    let defaultFeeAmount = "0"
 
 
     let confirmTitle = ""
@@ -137,6 +138,9 @@ class SendPage extends React.Component {
             toAddressCanInputDefaultValue = currentAccount.address
             sendAction = WALLET_SEND_RUNTIME_WITHDRAW
           }
+          // A wild guess: the minimum gas price on Emerald (10 nano ROSE) times the default loose
+          // overestimate of the gas (50k).
+          defaultFeeAmount = "500000"
         }
 
         pageTitle = getLanguage('send')
@@ -207,6 +211,7 @@ class SendPage extends React.Component {
       toAddressShowValue,
       runtimeType,
       runtimeId,
+      defaultFeeAmount,
       confirmTitle,
       confirmToAddressTitle,
       sendAction,
@@ -541,7 +546,7 @@ class SendPage extends React.Component {
       return
     }
 
-    feeAmount = feeAmount || 0
+    feeAmount = feeAmount || this.pageConfig.defaultFeeAmount
     feeGas = feeGas || 0
     let payFee = new BigNumber(amountDecimals(feeAmount)).toString()
 
@@ -622,7 +627,7 @@ class SendPage extends React.Component {
     let nonce = trimSpace(this.state.nonce) || accountInfo.nonce
     let fromAddress = currentAccount.address
 
-    let feeAmount = trimSpace(this.state.feeAmount)
+    let feeAmount = trimSpace(this.state.feeAmount) || this.pageConfig.defaultFeeAmount
     let feeGas = trimSpace(this.state.feeGas)
 
     let depositAddress = ""
@@ -734,7 +739,7 @@ class SendPage extends React.Component {
     let netNonce = isNumber(accountInfo.nonce) ? accountInfo.nonce : ""
     let nonce = this.state.nonce ? this.state.nonce : netNonce
 
-    let feeAmount = this.state.feeAmount ? this.state.feeAmount : 0
+    let feeAmount = this.state.feeAmount ? this.state.feeAmount : this.pageConfig.defaultFeeAmount
     feeAmount = toNonExponential(amountDecimals(feeAmount, cointypes.decimals))
     let title = ""
     let toTitle = ""

--- a/src/popup/pages/Send/index.js
+++ b/src/popup/pages/Send/index.js
@@ -425,7 +425,7 @@ class SendPage extends React.Component {
         />}
         <CustomInput
           value={this.state.feeAmount}
-          placeholder={"Fee Amount"}
+          placeholder={`Fee Amount (nano ${this.props.netConfig.currentSymbol})`}
           onTextInput={this.onFeeInput}
         />
         <CustomInput

--- a/src/popup/pages/Send/index.js
+++ b/src/popup/pages/Send/index.js
@@ -139,8 +139,8 @@ class SendPage extends React.Component {
             sendAction = WALLET_SEND_RUNTIME_WITHDRAW
           }
           // A wild guess: the minimum gas price on Emerald (10 nano ROSE) times the default loose
-          // overestimate of the gas (50k).
-          defaultFeeAmount = "500000"
+          // overestimate of the gas (15k).
+          defaultFeeAmount = "150000"
         }
 
         pageTitle = getLanguage('send')

--- a/src/popup/pages/Send/index.js
+++ b/src/popup/pages/Send/index.js
@@ -543,7 +543,7 @@ class SendPage extends React.Component {
 
     feeAmount = feeAmount || 0
     feeGas = feeGas || 0
-    let payFee = new BigNumber(amountDecimals(feeAmount)).multipliedBy(feeGas).toString()
+    let payFee = new BigNumber(amountDecimals(feeAmount)).toString()
 
 
     let checkStatus = this.checkBalanceEnough(amount,payFee)


### PR DESCRIPTION
proposed upcoming changes to Emerald will require a minimum gas price, which will make zero-fee withdrawal stop working

this is a minimal patch to use a hardcoded value for a withdrawal fee (that being the only non-deposit paratime transaction supported). we're interested in querying the minimum gas price in a larger change #227

reviewers, be on your guard. I don't know if I'm right about these changes
