### PR TITLE
Prepare release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 1.4.0
+
+Spotlight change:
+
+- We fixed a problem where we checked for the wrong fields when signing
+  certain transactions when using the extension with a dApp. As a result,
+  dApps can now request signatures for more kinds of transactions
+  ([#249](https://github.com/oasisprotocol/oasis-wallet-ext/issues/249)).
+
+Little things:
+
+- Error message "toast" notifications now show up for longer
+  ([#242](https://github.com/oasisprotocol/oasis-wallet-ext/pull/242)).
+- Instructions for how to connect a Ledger device are more detailed
+  ([#248](https://github.com/oasisprotocol/oasis-wallet-ext/pull/248)).
+- We're a little smarter about when to show a warning when depositing into the
+  Cipher ParaTime
+  ([#245](https://github.com/oasisprotocol/oasis-wallet-ext/pull/245)).
+
 ## 1.3.1
 
 Little things:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oasis-wallet",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "build": "webpack --mode production",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "__MSG_appName__",
   "description": "__MSG_appDescription__",
   "manifest_version": 2,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "default_locale": "en",
   "icons": {
     "16": "img/oasis.png",


### PR DESCRIPTION
One of our partners is interested in building a dApp, and they wanted to be able to sign some non-transfer transaction types over the ext-utils interface. We've now merged a fix for that, so it'll be nice to get this out.