### PR TITLE
Only show hardcoded paratimes

### DIFF
--- a/src/background/api/index.js
+++ b/src/background/api/index.js
@@ -1,6 +1,6 @@
 import * as oasis from "@oasisprotocol/client";
 import { cointypes, TX_LIST_LENGTH } from "../../../config";
-import { amountDecimals, isNumber } from "../../utils/utils";
+import { amountDecimals, getRuntimeConfig, isNumber } from "../../utils/utils";
 import { commonFetch, getOasisClient } from "./request";
 import { getRpcAccount } from "./rpc";
 import * as oasisRT from "@oasisprotocol/client-rt";
@@ -186,6 +186,8 @@ export async function getRpcRuntimeList() {
     const runtime = runtimeList[index];
     let id = runtime.id;
     let runtimeId = oasis.misc.toHex(id);
+    let runtimeConfig = getRuntimeConfig(runtimeId);
+    if (!runtimeConfig) continue; // Only keep runtimes from PARATIME_CONFIG
     list.push({
       name: "unknown",
       runtimeId: runtimeId,

--- a/src/reducers/accountReducer.js
+++ b/src/reducers/accountReducer.js
@@ -153,6 +153,7 @@ const setRuntimeName=(currentAccount,runtimeList)=>{
     for (let index = 0; index < runtimeList.length; index++) {
         let runtime = runtimeList[index];
         let runtimeConfig = getRuntimeConfig(runtime.runtimeId)
+        if (!runtimeConfig) continue // Only keep runtimes from PARATIME_CONFIG
         let isEmerald = runtimeConfig.accountType === RUNTIME_ACCOUNT_TYPE.EVM
         let config = {
             ...runtime,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -304,19 +304,17 @@ export async function getEvmBech32Address(evmAddress){
  * @returns
  */
 export function getRuntimeConfig(runtimeId){
-    let runtimeConfig = {}
     for (let index = 0; index < PARATIME_CONFIG.length; index++) {
         const runtime = PARATIME_CONFIG[index];
         let runtimeIdList = runtime.runtimeIdList
         for (let j = 0; j < runtimeIdList.length; j++) {
             let config = runtimeIdList[j]
             if(runtimeId === config.runtimeId){
-                runtimeConfig = runtime
-                return runtimeConfig
+                return runtime
             }
         }
     }
-    return runtimeConfig
+    return undefined
 }
 
 /**


### PR DESCRIPTION
Testnet already has an unknown runtime registered, and it throws `Error: client: no hosted runtime is available` when wallet tries to query its accounts.Balances. Hide it for now.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/3758846/167511066-b8324539-add7-44b4-884d-86f7d9009984.png)    |  ![after](https://user-images.githubusercontent.com/3758846/167511059-fa1290c6-1f90-4232-bc1c-c949087312db.png) |