### PR TITLE
Fix displaying errors from background page

### DIFF
--- a/src/background/messageListener.js
+++ b/src/background/messageListener.js
@@ -38,7 +38,24 @@ import apiService from "./service/APIService";
 import extDappService from "./service/ExtDappService";
 import { openPopupWindow } from '../utils/popup';
 
-function internalMessageListener(message, sender, sendResponse) {
+function internalMessageListener(message, sender, sendResponseSerializable) {
+  const sendResponse = (response) => {
+    if (response?.error instanceof Error) {
+      return sendResponseSerializable({
+        ...response,
+        error: {
+          // Name, message, and stack are non-enumerable, so by default errors
+          // would serialize to "{}".
+          ...response.error,
+          name: response.error.name,
+          message: response.error.message,
+          stack: response.error.stack,
+        }
+      })
+    }
+    return sendResponseSerializable(response)
+  }
+
   const { messageSource, action, payload } = message;
   if (messageSource) {
     return false


### PR DESCRIPTION
Made errors serializable for sendResponse.

Fixes https://github.com/oasisprotocol/oasis-wallet-ext/issues/176