### PR TITLE
Fix signing transactions after importing from short private keys

### DIFF
--- a/src/background/service/APIService.js
+++ b/src/background/service/APIService.js
@@ -309,8 +309,7 @@ class APIService {
     }
     parseKey = (key) => {
         try {
-            const keyWithoutEnvelope = trimSpace(key)
-            const key_bytes = decode(keyWithoutEnvelope)
+            const key_bytes = decode(trimSpace(key))
             return this.fromPrivateKey(new Uint8Array(key_bytes))
         } catch (e) {
             throw e

--- a/src/background/service/APIService.js
+++ b/src/background/service/APIService.js
@@ -293,13 +293,13 @@ class APIService {
             return this.getAccountWithoutPrivate(account)
         }
     };
+    /** @param {Uint8Array} key */
     fromPrivateKey = (key) => {
         try {
             if (key.length === 32) {
                 return nacl.sign.keyPair.fromSeed(key).secretKey
             } else if (key.length === 64) {
-                let res = nacl.sign.keyPair.fromSecretKey(key).secretKey
-                return res
+                return nacl.sign.keyPair.fromSecretKey(key).secretKey
             } else {
                 throw new Error('Invalid private key shape')
             }
@@ -307,6 +307,7 @@ class APIService {
             throw e
         }
     }
+    /** @param {string} key */
     parseKey = (key) => {
         try {
             const key_bytes = decode(trimSpace(key))
@@ -317,8 +318,7 @@ class APIService {
     }
     /**
      * import wallet by ed25519 private key
-     * @param {*} key
-     * @returns
+     * @param {string} privateBase64
      */
     importWalletByPrivateKey = async (privateBase64) => {
         let secretKey = this.parseKey(privateBase64)
@@ -337,7 +337,7 @@ class APIService {
     }
     /**
      * import wallet by secp256k1 private key
-     * @param {*} privKey
+     * @param {string} priKey
      * @returns
      */
     importSecWalletByPrivateKey = async (priKey) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -83,13 +83,11 @@ export function getAmountForUI(rawAmount, decimal = cointypes.decimals) {
 
 
 /**
- * Remove the spaces before and after the string
- * @param {*} str
+ * Remove the spaces before and after the string and remove newlines
+ * @param {string} str
  */
 export function trimSpace(str) {
-    let res = str.replace(/(^\s*)|(\s*$)/g, "")
-    res = res.replace(/[\r\n]/g, "")
-    return res
+    return str.replace(/(^\s*)|(\s*$)/g, "").replace(/[\r\n]/g, "")
 }
 
 /**


### PR DESCRIPTION
It looks like this has been broken since the beginning :scream: 

If user imported an account from a short private key "seed", signing any transaction failed:
- Import from private key `oPNmZybIOymrQCpCGGICczsaopANP02kwOhCyxETXlg=`
- Send 1 TEST to self
- Error `Transaction broadcast failed`

Compared to long private key "secret key":
- Import from private key `oPNmZybIOymrQCpCGGICczsaopANP02kwOhCyxETXljLLmRChL1QJGzJq3Pf3i+dFBN+peIK2vQ3Ew0wSQbp3g==`
- Send 1 TEST to self
- Success