### PR TITLE
Add work-around to ensure building works with Node.js 16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.9.0",
   "private": true,
   "scripts": {
-    "build": "webpack --mode production",
-    "buildProd": "webpack --mode production",
-    "dev": "webpack --mode development --progress --watch",
+    "build": "env NODE_OPTIONS=--openssl-legacy-provider webpack --mode production",
+    "buildProd": "env NODE_OPTIONS=--openssl-legacy-provider webpack --mode production",
+    "dev": "env NODE_OPTIONS=--openssl-legacy-provider webpack --mode development --progress --watch",
     "lint": "yarn run eslint src",
     "test": "jest"
   },


### PR DESCRIPTION
Node.js 16+ supports dynamically linking with OpenSSL 3.0, however, that results in `error:0308010C:digital envelope routines::unsupported` error.

To work-around that with the legacy Webpack 4.0 we use, one needs to enable the OpenSSL 3.0 Legacy provider by setting:

```
NODE_OPTIONS=--openssl-legacy-provider
```

For more info, see:
- https://github.com/webpack/webpack/issues/14532
- https://github.com/nodejs/node/issues/40455
- https://github.com/nodejs/node/issues/40948

Closes #304.