### PR TITLE
Fix opening popup (error "Bounds must be at least 50% within visible screen space")

### DIFF
--- a/src/background/service/ExtDappService.js
+++ b/src/background/service/ExtDappService.js
@@ -262,10 +262,9 @@ class ExtDappService {
   }
   async dappOpenPopWindow(url,
     channel = "default",
-    windowType = "",
-    options = {}) {
+    windowType = "") {
     let that = this
-    let popupWindowId = await openPopupWindow(url, channel, windowType, options)//获取到windowId
+    let popupWindowId = await openPopupWindow(url, channel, windowType, {})//获取到windowId
     this.setCurrentOpenWindow(url, channel)
     let listener = extension.tabs.onRemoved.addListener(function (tabInfo, changeInfo) {
       if (popupWindowId === changeInfo.windowId) {

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -81,12 +81,19 @@ export async function openPopupWindow(
       ...dappOption
     }
   }
-  const option = Object.assign({
+  let option = Object.assign({
     width: PopupSize.width,
     height: PopupSize.height,
     url: url,
     type: /** @type {const} */ ("popup"),
   }, options);
+
+  if (option.left && option.width && option.left + option.width > screen.width) {
+    option.left = screen.width - option.width
+  }
+  if (option.top && option.height && option.top + option.height > screen.height) {
+    option.top = screen.height - option.height
+  }
 
   if (lastWindowIds[channel] !== undefined) {
     try {

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -169,17 +169,20 @@ export function openCurrentRouteInPersistentPopup() {
     // opening Welcome page popup twice, after window.close().
     url.searchParams.set('fixImagesDisappearing', '' + Math.random());
 
-    // Call openPopupWindow through background script, so lastWindowIds isn't
-    // lost, and popup is reused if called multiple times.
-    sendMsg({
-      action: WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP,
-      payload: {
-        left: window.screenLeft,
-        top: window.screenTop,
-        route: url.pathname + url.search + url.hash,
-      },
-    }, () => {});
-    window.close();
+    // Add slight delay so `window.screenLeft` returns popup's position, not extension's icon position
+    setTimeout(() => {
+      // Call openPopupWindow through background script, so lastWindowIds isn't
+      // lost, and popup is reused if called multiple times.
+      sendMsg({
+        action: WALLET_OPEN_ROUTE_IN_PERSISTENT_POPUP,
+        payload: {
+          left: window.screenLeft,
+          top: window.screenTop,
+          route: url.pathname + url.search + url.hash,
+        },
+      }, () => {});
+      window.close();
+    }, 100)
   } else {
     fitPopupWindow();
   }


### PR DESCRIPTION
If user freshly installs extension, opens popup, closes it, opens popup:
- popup initializes very quickly
- window.screenLeft in openCurrentRouteInPersistentPopup returns extension's
  icon position (instead of popup) near the edge of the screen
- Chrome blocks popup "Bounds must be at least 50% within visible screen space"
- user can't open the popup

This only happens with production build. In development build javascript is loaded slower, and window.screenLeft returns popup position.